### PR TITLE
Fixes issue #85

### DIFF
--- a/spotpy/parameter.py
+++ b/spotpy/parameter.py
@@ -488,7 +488,7 @@ def create_set(setup, random=False, **kwargs):
     params = get_parameters_array(setup)
 
     # Create the namedtuple from the parameter names
-    partype = get_namedtuple_from_paramnames(type(setup).__name__, params['name'])
+    partype = get_namedtuple_from_paramnames(setup, params['name'])
 
     # Get the values
     if random:


### PR DESCRIPTION
The function `get_namedtuple_from_paramnames` expects a setup object but is instead being given the name of the class.