### PR TITLE
Fix mpl backend

### DIFF
--- a/spotpy/analyser.py
+++ b/spotpy/analyser.py
@@ -16,8 +16,6 @@ Note: This part of SPOTPY is in alpha status and not ready for production use.
 
 import numpy as np
 import spotpy
-import os
-import matplotlib as mpl
 
 
 

--- a/spotpy/analyser.py
+++ b/spotpy/analyser.py
@@ -17,11 +17,7 @@ Note: This part of SPOTPY is in alpha status and not ready for production use.
 import numpy as np
 import spotpy
 import os
-try:
-    test_os_environment = os.environ['DISPLAY']
-except KeyError:
-    import matplotlib as mpl
-    mpl.use('Agg')
+import matplotlib as mpl
 
 
 

--- a/spotpy/unittests/test_analyser.py
+++ b/spotpy/unittests/test_analyser.py
@@ -12,6 +12,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import matplotlib as mpl
+mpl.use('Agg')
+import matplotlib.pyplot as plt
 
 try:
     import spotpy
@@ -25,9 +28,6 @@ import numpy as np
 import spotpy.analyser
 import os
 import pickle
-import matplotlib as mpl
-mpl.use('Agg')
-import matplotlib.pyplot as plt
 
 
 class TestAnalyser(unittest.TestCase):


### PR DESCRIPTION
A "fix" in analyser.py does not allow to select different matplotlib backends on Windows. Removed the "fix" and solved the test problem by reordering imports in the test. A good rule is to first import standard packages, than external packages and local imports as last. Not always necessary, but here it is nice.