### PR TITLE
[WIP] Named parameters fail for some samplers

### DIFF
--- a/spotpy/algorithms/_algorithm.py
+++ b/spotpy/algorithms/_algorithm.py
@@ -140,7 +140,6 @@ class _algorithm(object):
                  db_precision=np.float16, sim_timeout=None, random_state=None):
         # Initialize the user defined setup class
         self.setup = spot_setup
-        self.model = self.setup.simulation
         # Philipp: Changed from Tobi's version, now we are using both new class defined parameters
         # as well as the parameters function. The new method get_parameters
         # can deal with a missing parameters function
@@ -359,7 +358,7 @@ class _algorithm(object):
         # we need a layer to fetch returned data from a threaded process into a queue.
         def model_layer(q,all_params):
             # Call self.model with a namedtuple instead of another sequence
-            q.put(self.model(self.partype(*all_params)))
+            q.put(self.setup.simulation(self.partype(*all_params)))
 
         # starting a queue, where in python2.7 this is a multiprocessing class and can cause errors because of
         # incompability which the main thread. Therefore only for older Python version a workaround follows

--- a/spotpy/algorithms/mle.py
+++ b/spotpy/algorithms/mle.py
@@ -78,7 +78,7 @@ class mle(_algorithm):
         for i in range(burnIn):
             randompar = self.parameter()['random']
             pars.append(randompar)
-            simulations = self.model(randompar)
+            _, _, simulations = self.simulate((i, randompar))
             sims.append(simulations)
             like = self.postprocessing(i, randompar, simulations)
             likes.append(like)
@@ -93,7 +93,7 @@ class mle(_algorithm):
             # Use stepsize provided for every dimension.
             new_par = np.random.normal(loc=old_par, scale=stepsizes)
             new_par = self.check_par_validity(new_par)
-            new_simulations = self.model(new_par)
+            _, _, new_simulations = self.simulate((i, new_par))
             new_like = self.postprocessing(rep+burnIn, new_par, new_simulations)
             # Accept new candidate in Monte-Carlo fashing.
             if (new_like > old_like):

--- a/spotpy/algorithms/sa.py
+++ b/spotpy/algorithms/sa.py
@@ -85,7 +85,7 @@ class sa(_algorithm):
         Titer = Tini
         x = self.parameter()['optguess']
         Xopt = x
-        simulations = self.model(x)
+        _, _, simulations = self.simulate((1, x))
         Enew = self.postprocessing(1, x, simulations)
         Eopt = Enew
         rep = 0
@@ -109,7 +109,7 @@ class sa(_algorithm):
 
                 x = self.check_par_validity(x)
 
-                simulations = self.model(x)
+                _, _, simulations = self.simulate((rep+1, x))
                 Enew = self.postprocessing(rep+1, x, simulations)
                 rep += 1
 

--- a/spotpy/algorithms/sceua.py
+++ b/spotpy/algorithms/sceua.py
@@ -88,8 +88,7 @@ class sceua(_algorithm):
         """
         
         if not self.repeat.phase:  # burn-in
-            id, params = id_params_tuple
-            return id, params, self.model(params)
+            return _algorithm.simulate(self, id_params_tuple)
 
         else:  # complex-evolution
             igs, x, xf, icall, cx, cf, sce_vars = id_params_tuple
@@ -235,6 +234,8 @@ class sceua(_algorithm):
             idx = np.argsort(xf)
             xf = np.sort(xf)
             x = x[idx, :]
+        else:
+            raise ValueError("Don't know the breakpoint keyword {}".format(self.breakpoint))
         
         # Record the best and worst points;
         bestx = x[0, :]
@@ -428,7 +429,7 @@ class sceua(_algorithm):
             snew = self._sampleinputmatrix(1, self.nopt)[0]  # checken!!
 
         ##    fnew = functn(self.nopt,snew);
-        simulations = self.model(snew)
+        _, _, simulations = _algorithm.simulate(self, (icall, snew))
         like = self.postprocessing(icall, snew, simulations, save=False)
         #like = self.objectivefunction(
         #    evaluation=self.evaluation, simulation=simulations)
@@ -442,7 +443,7 @@ class sceua(_algorithm):
             snew = sw + beta * (ce - sw)
             snew[constant_parameters] = sw[constant_parameters]
 
-            simulations = self.model(snew)
+            _, _, simulations = _algorithm.simulate(self, (icall, snew))
             like = self.postprocessing(icall, snew, simulations, save=False)
 #            like = self.objectivefunction(
 #                evaluation=self.evaluation, simulation=simulations)
@@ -452,7 +453,7 @@ class sceua(_algorithm):
         # Both reflection and contraction have failed, attempt a random point;
             if fnew > fw:
                 snew = self._sampleinputmatrix(1, self.nopt)[0]  # checken!!
-                simulations = self.model(snew)
+                _, _, simulations = _algorithm.simulate(self, (icall, snew))
                 like = self.postprocessing(icall, snew, simulations, save=False)
 #                like = self.objectivefunction(
 #                    evaluation=self.evaluation, simulation=simulations)

--- a/spotpy/unittests/test_setup_parameters.py
+++ b/spotpy/unittests/test_setup_parameters.py
@@ -115,8 +115,8 @@ class TestSetupVariants(unittest.TestCase):
         self.assertEqual(param_names, 'a,b,c,d', '{} Parameter names should be "a,b,c,d" but got "{}"'
                          .format(o, param_names))
 
-    def make_sampler(self, o):
-        sampler = spotpy.algorithms.mc(spot_setup=o, dbformat='ram')
+    def make_sampler(self, o, algo=spotpy.algorithms.mc):
+        sampler = algo(spot_setup=o, dbformat='ram')
         sampler.sample(10)
 
     def test_parameter_class(self):
@@ -138,7 +138,49 @@ class TestSetupVariants(unittest.TestCase):
         for o in self.objects:
             self.make_sampler(o)
 
+    def test_abc_sampler(self):
+        for o in self.objects:
+            self.make_sampler(o, spotpy.algorithms.abc)
 
-if __name__ == '__main__':
+    def test_demcz_sampler(self):
+        for o in self.objects:
+            self.make_sampler(o, spotpy.algorithms.demcz)
+
+    def test_dream_sampler(self):
+        for o in self.objects:
+            self.make_sampler(o, spotpy.algorithms.dream)
+
+    def test_fscabc_sampler(self):
+        for o in self.objects: self.make_sampler(o, spotpy.algorithms.fscabc)
+
+    def test_lhs_sampler(self):
+        for o in self.objects:
+            self.make_sampler(o, spotpy.algorithms.lhs)
+
+    def test_mc_sampler(self):
+        for o in self.objects:
+            self.make_sampler(o, spotpy.algorithms.mc)
+
+    def test_mcmc_sampler(self):
+        for o in self.objects:
+            self.make_sampler(o, spotpy.algorithms.mcmc)
+
+    def test_mle_sampler(self):
+        for o in self.objects: self.make_sampler(o, spotpy.algorithms.mle)
+
+    def test_rope_sampler(self):
+        for o in self.objects:
+            self.make_sampler(o, spotpy.algorithms.rope)
+
+    def test_sa_sampler(self):
+        for o in self.objects:
+            self.make_sampler(o, spotpy.algorithms.sa)
+
+    def test_sceua_sampler(self):
+        for o in self.objects:
+            self.make_sampler(o, spotpy.algorithms.sceua)
+
+
+if __name__ == '_main__':
     unittest.main(verbosity=3)
 


### PR DESCRIPTION
Fails for mle, sa and sceua. Contains the failing tests.

## Problem:
mle, sa and sceua call `setup.simulation` with an `np.array` and not with the parameter value object. Hence, one cannot use named parameters in `setup.simulation` as in `examples/spot_setup_cmf_lumped.py`