### PR TITLE
Customizable MPI repeater

### DIFF
--- a/spotpy/algorithms/_algorithm.py
+++ b/spotpy/algorithms/_algorithm.py
@@ -200,6 +200,19 @@ class _algorithm(object):
         If the model run has been broken simlply '[nan]' will be returned.
     random_state: int or None, default: None
         the algorithms uses the number in random_state as seed for numpy. This way stochastic processes can be reproduced.
+    parallel_kwargs: None or dict
+        Additional keyword arguments that are supplied to the ForEach repetition object.
+        Recognized keywords depend on the selected `parallel` mode:
+
+        mpi
+        ---
+        `mpicomm`: MPI.Intracomm:
+            A custom MPI communicator that is used for communication instead of
+            MPI_COMM_WORLD (default).
+        `on_worker_terminate`: callable
+            A custom callable that is called when all jobs have been processed and the
+            spotpy workers are terminated. This can be used to shutdown workers of the
+            setup level. The default implementation does nothing.
     """
 
     _unaccepted_parameter_types = (parameter.List, )
@@ -207,7 +220,7 @@ class _algorithm(object):
     def __init__(self, spot_setup, dbname=None, dbformat=None, dbinit=True,
                  dbappend=False, parallel='seq', save_sim=True, breakpoint=None,
                  backup_every_rep=100, save_threshold=-np.inf, db_precision=np.float16,
-                 sim_timeout=None, random_state=None, optimization_direction='grid', algorithm_name=''):
+                 sim_timeout=None, random_state=None, optimization_direction='grid', algorithm_name='', parallel_kwargs=None):
 
         # Initialize the user defined setup class
         self.setup = spot_setup
@@ -258,6 +271,7 @@ class _algorithm(object):
                 print('Backupfile not found')
             self.dbappend = True
 
+        parallel_kwargs = parallel_kwargs or {}
         # Now a repeater (ForEach-object) is loaded
         # A repeater is a convinent wrapper to repeat tasks
         # We have the same interface for sequential and for parallel tasks
@@ -286,7 +300,7 @@ class _algorithm(object):
         # setphase function. The simulate method can check the current phase and dispatch work
         # to other functions. This is introduced for sceua to differentiate between burn in and
         # the normal work on the chains
-        self.repeat = ForEach(self.simulate)
+        self.repeat = ForEach(self.simulate, **parallel_kwargs)
 
         # method "save" needs to know whether objective function result is list or float, default is float
         self.like_struct_typ = type(1.1)

--- a/spotpy/parallel/mpi.py
+++ b/spotpy/parallel/mpi.py
@@ -88,7 +88,9 @@ class ForEach(object):
         self.rank = self.comm.Get_rank()
         self.process = process
         self.phase = None
-        self.on_worker_terminate = None
+        self.on_worker_terminate = kwargs.get('on_worker_terminate', None)
+        if not callable(self.on_worker_terminate) and self.on_worker_terminate is not None:
+            raise TypeError('on_worker_terminate must be a callable of None')
         if self.rank == 0:
             # The slots are a place for the master to remember which worker is doing something
             # Idle slots contain None

--- a/spotpy/parallel/mproc.py
+++ b/spotpy/parallel/mproc.py
@@ -27,7 +27,7 @@ class ForEach(object):
     We using the pathos multiprocessing module and the orderd map function where results are saved until results in
     the given order are caluculated. We yielding back the result so a generator object is created.
     """
-    def __init__(self, process):
+    def __init__(self, process, **kwargs):
         self.size = process_count or mp.cpu_count()
         self.process = process
         self.phase=None

--- a/spotpy/parallel/sequential.py
+++ b/spotpy/parallel/sequential.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 class ForEach(object):
-    def __init__(self,process):
+    def __init__(self,process, **kwargs):
         self.process = process
         self.phase=None
     def is_idle(self):

--- a/spotpy/parallel/umproc.py
+++ b/spotpy/parallel/umproc.py
@@ -27,7 +27,7 @@ class ForEach(object):
     We using the pathos multiprocessing module and the unordered map function where results are yield back while some
     processes are still running.
     """
-    def __init__(self, process):
+    def __init__(self, process, **kwargs):
         self.size = process_count or mp.cpu_count()
         self.process = process
         self.phase = None


### PR DESCRIPTION
### Use case
In some situations, users don't want to use `MPI_COMM_WORLD` in spotpy, but a custom communicator. E.g. to run `spotpy` only on selected processes. This can be achieved easily by providing a custom communicator object when `mpi.ForEach` is created.

Additionally, some advanced setups use parallelization such as `MPI` internally to crunch the numbers inside `heavy_setup.simulate()`, thereby establishing a second level of parallelization. This requires a custom communicator as well as a custom way to terminate spotpy workers, e.g. terminate setup workers as well.

### Solutions
- a custom `MPI` intra-communicator can be passed to  `_algorithm` via `parallel_kwargs` (implementations support the concept of argument forwarding already, nothing to do here)
- a custom `on_worker_terminate` callback can be passed to  `_algorithm` via the `parallel_kwargs`