### PR TITLE
add params_min/max into break point pickle

### DIFF
--- a/spotpy/algorithms/_algorithm.py
+++ b/spotpy/algorithms/_algorithm.py
@@ -366,17 +366,19 @@ class _algorithm(object):
             Reason: In case of incomplete optimizations, old data can be restored. '''
         import pickle
         with open(dbname+'.break', 'rb') as breakfile:
-            work,backuptime,repos,obmin,obmax=pickle.load(breakfile)
+            work,backuptime,repos,obmin,obmax,pmin,pmax=pickle.load(breakfile)
             self.status.starttime=self.status.starttime-backuptime
             self.status.rep=repos
             self.status.objectivefunction_min=obmin
             self.status.objectivefunction_max=obmax
+            self.status.params_min=pmin
+            self.status.params_max=pmax
             return work
 
     def write_breakdata(self, dbname, work):
         ''' Write data to a pickle file if a breakpoint has been set.'''
         import pickle
-        work=(work,self.status.last_print-self.status.starttime,self.status.rep,self.status.objectivefunction_min,self.status.objectivefunction_max)
+        work=(work,self.status.last_print-self.status.starttime,self.status.rep,self.status.objectivefunction_min,self.status.objectivefunction_max,self.status.params_min,self.status.params_max)
         with open(str(dbname)+'.break', 'wb') as breakfile:
             pickle.dump(work, breakfile)
 


### PR DESCRIPTION
_algorithm.py:

The variables params_min/max are not stored in the break point database. As they are not recomputed after a restart they eventually may not get updated, if no new min/max was achieved in the continued run.

Could you please check if there may be other candidates like this?  