### PR TITLE
Fix np.float16 to string conversion

### DIFF
--- a/spotpy/analyser.py
+++ b/spotpy/analyser.py
@@ -180,7 +180,7 @@ def get_minlikeindex(results):
     except ValueError:
         likes=results['like1']
     minimum=np.nanmin(likes)
-    value=str(round(minimum,4))
+    value=np.format_float_positional(minimum, 4)
     text=str('Run number ' )
     index=np.where(likes==minimum)
     text2=str(' has the lowest objectivefunction with: ')


### PR DESCRIPTION
Based on [this](https://github.com/numpy/numpy/issues/13699) bug report in numpy's repo, rounding a `np.float16` could lead to `inf`. So instead, I propose to use a numpy function for converting a float to str. For example:

```python
np.format_float_positional(np.float16(7.33), 4)
```
correctly return `7.33` but:

```python
str(round(np.float16(7.33), 4))
```
returns `inf`.