### PR TITLE
Typo adjustments, black formatting, drop Python 3.9, support Python 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   source_check:
-    name: source check
+    name: Linting (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -36,8 +36,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black 'isort[colors]<6'
-          pip install --editable .
+          python -m pip install black 'isort[colors]<6'
+          python -m pip install --editable .
 
       - name: isort check
         run: |
@@ -66,12 +66,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build pytest-cov
-          pip install --editable .[test]
+          python -m pip install build pytest-cov
+          python -m pip install --editable .[test]
 
       - name: Run tests
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python -m pytest --cov spotpy --cov-report term-missing -v tests/
 
@@ -80,6 +78,8 @@ jobs:
         run: |
           python -m pip install coveralls
           python -m coveralls --service=github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build sdist
         if: matrix.python-version == '3.13'
@@ -93,7 +93,9 @@ jobs:
           path: dist/
 
   upload_to_pypi:
-    needs: [build_sdist]
+    name: Upload to PyPI/Test PyPI
+    needs:
+      - build_sdist
     runs-on: ubuntu-latest
     steps:
       - name: Download all the dists

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build coveralls>=3.0.0
+          pip install build pytest-cov
           pip install --editable .[test]
 
       - name: Run tests
@@ -74,15 +74,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python -m pytest --cov spotpy --cov-report term-missing -v tests/
+
+      - name: Upload coverage to Coveralls
+        if: matrix.python-version != '3.13'
+        run: |
+          python -m pip install coveralls
           python -m coveralls --service=github
 
       - name: Build sdist
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         run: |
           python -m build
 
       - uses: actions/upload-artifact@v4
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         with:
           name: dist-sdist
           path: dist/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,14 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        python-version: [ '3.12' ]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
@@ -39,16 +41,17 @@ jobs:
 
       - name: isort check
         run: |
+          python -m black --check --diff --color .
           python -m isort --check --diff --color .
 
   build_sdist:
-    name: sdist on ${{ matrix.os }} with py ${{ matrix.python-version }}
+    name: sdist on ${{ matrix.os }} with Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.12']
+        os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
+        python-version: [ '3.9', '3.12' ]
 
     steps:
       - uses: actions/checkout@v4
@@ -74,6 +77,7 @@ jobs:
           python -m coveralls --service=github
 
       - name: Build sdist
+        if: matrix.python-version == '3.12'
         run: |
           python -m build
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
-        python-version: [ '3.9', '3.12' ]
+        python-version: [ '3.10', '3.13' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -16,17 +16,13 @@ A Statistical Parameter Optimization Tool for Python
 [license-image]: https://img.shields.io/badge/license-MIT-blue.png
 [license-link]: http://opensource.org/licenses/MIT
 
-
-
 Purpose
-=================
-
+=======
 
 https://github.com/user-attachments/assets/4df71cb2-dcf9-4a24-bb78-6e4e1c43356a
 
-
 SPOTPY is a Python framework that enables the use of Computational optimization techniques for calibration, uncertainty
-and sensitivity analysis techniques of almost every (environmental-) model. The package is puplished in the open source journal PLoS One:
+and sensitivity analysis techniques of almost every (environmental-) model. The package is published in the open source journal PLoS One:
 
 Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.: SPOTting Model Parameters Using a Ready-Made Python Package, PLoS ONE,
 10(12), e0145180, doi:[10.1371/journal.pone.0145180](http://journals.plos.org/plosone/article?id=10.1371%2Fjournal.pone.0145180 "SPOTting Model Parameters Using a Ready-Made Python Package"), 2015
@@ -39,10 +35,8 @@ algorithms of almost any model, without the need of complex codes::
 	results = sampler.getdata()                          # Load the results
 	spotpy.analyser.plot_parametertrace(results)         # Show the results
 
-
-
 Features
-=================
+========
 
 Complex algorithms bring complex tasks to link them with a model.
 We want to make this task as easy as possible.
@@ -65,7 +59,7 @@ Some features you can use with the SPOTPY package are:
   * Artificial Bee Colony (`ABC`)
   * Fitness Scaled Chaotic Artificial Bee Colony (`FSCABC`)
   * Dynamically Dimensioned Search algorithm (`DDS`)
-  * Pareto Archived - Dynamicallly Dimensioned Search algorithm (`PA-DDS`)
+  * Pareto Archived - Dynamically Dimensioned Search algorithm (`PA-DDS`)
   * Fast and Elitist Multiobjective Genetic Algorithm (`NSGA-II`)
 
 * Wide range of objective functions (also known as loss function, fitness function or energy function) to validate the sampled results. Available functions are
@@ -84,7 +78,7 @@ Some features you can use with the SPOTPY package are:
   * Agreement Index (`AI`)
   * Covariance, Decomposed MSE (`dMSE`)
   * Kling-Gupta Efficiency (`KGE`)
-  * Non parametric Kling-Gupta Efficiency (`KGE_non_parametric`)
+  * Non-parametric Kling-Gupta Efficiency (`KGE_non_parametric`)
 
 * Wide range of hydrological signatures functions to validate the sampled results:
 
@@ -102,12 +96,12 @@ Some features you can use with the SPOTPY package are:
 
   * Uniform
   * Normal
-  * logNormal
-  * Chisquare
+  * log-normal
+  * Chi-Square
   * Exponential
   * Gamma
   * Wald
-  * Weilbull
+  * Weibull
 
 * Wide range to adapt algorithms to perform uncertainty-, sensitivity analysis or calibration
   of a model.
@@ -137,7 +131,7 @@ Some features you can use with the SPOTPY package are:
 
 
 Install
-=================
+=======
 
 Classical Python options exist to install SPOTPY:
 
@@ -157,7 +151,7 @@ From [Source](https://pypi.python.org/pypi/spotpy):
 
 
 Support
-=================
+=======
 
 * Documentation: https://spotpy.readthedocs.io/en/latest/
 
@@ -171,12 +165,12 @@ Support
 
 
 Getting started
-=================
+===============
 Have a look at https://github.com/thouska/spotpy/tree/master/spotpy/examples and https://spotpy.readthedocs.io/en/latest/getting_started/
 
 
 Contributing
-=================
+============
 Patches/enhancements/new algorithms and any other contributions to this package are very welcome!
 
 1. Fork it ( http://github.com/thouska/spotpy/fork )
@@ -188,5 +182,5 @@ Patches/enhancements/new algorithms and any other contributions to this package 
 7. Create new Pull Request
 
 Papers citing SPOTPY
-=====================
+====================
 See [Google Scholar](https://scholar.google.de/scholar?cites=17155001516727704728&as_sdt=2005&sciodt=0,5&hl=de) for a continuously updated list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,11 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Hydrology",
     "Topic :: Scientific/Engineering :: Mathematics",
@@ -106,7 +109,11 @@ multi_line_output = 3
 [tool.black]
 exclude = "_version.py"
 target-version = [
+    "py39",
+    "py310",
+    "py311",
 	"py312",
+    "py313",
 ]
 
 [tool.coverage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 name = "spotpy"
 description = "A Statistical Parameter Optimization Tool."
 authors = [
@@ -55,7 +55,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/src/spotpy/algorithms/__init__.py
+++ b/src/spotpy/algorithms/__init__.py
@@ -6,8 +6,8 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 :author: Tobias Houska
 
-:paper: Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.: 
-SPOTting Model Parameters Using a Ready-Made Python Package, 
+:paper: Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.:
+SPOTting Model Parameters Using a Ready-Made Python Package,
 PLoS ONE, 10(12), e0145180, doi:10.1371/journal.pone.0145180, 2015.
 
 Imports the different algorithms from this package.

--- a/src/spotpy/algorithms/_algorithm.py
+++ b/src/spotpy/algorithms/_algorithm.py
@@ -5,6 +5,7 @@ This file is part of Statistical Parameter Optimization Tool for Python(SPOTPY).
 
 This file holds the standards for every algorithm.
 """
+
 import random
 import threading
 import time
@@ -516,9 +517,9 @@ class _algorithm(object):
         can mix up the ordering of runs
         """
         id, params = id_params_tuple
-        self.all_params[
-            self.non_constant_positions
-        ] = params  # TODO: List parameters are not updated if not accepted for the algorithm, we may have to warn/error if list is given
+        self.all_params[self.non_constant_positions] = (
+            params  # TODO: List parameters are not updated if not accepted for the algorithm, we may have to warn/error if list is given
+        )
         all_params = self.all_params
 
         if self.sim_timeout:
@@ -528,7 +529,7 @@ class _algorithm(object):
                 q.put(self.setup.simulation(self.partype(*all_params)))
 
             # starting a queue, where in python2.7 this is a multiprocessing class and can cause errors because of
-            # incompability which the main thread. Therefore only for older Python version a workaround follows
+            # incompability which the main thread. Therefore, only for older Python version a workaround follows
             que = Queue()
 
             sim_thread = threading.Thread(target=model_layer, args=(que, all_params))

--- a/src/spotpy/algorithms/abc.py
+++ b/src/spotpy/algorithms/abc.py
@@ -78,9 +78,7 @@ class abc(_algorithm):
             sets the limit
         """
         self.set_repetiton(repetitions)
-        print(
-            "Starting the ABC algorithm with " + str(repetitions) + " repetitions..."
-        )
+        print(f"Starting the ABC algorithm with {repetitions} repetitions...")
         # Initialize ABC parameters:
         randompar = self.parameter()["random"]
         self.nopt = randompar.size

--- a/src/spotpy/algorithms/abc.py
+++ b/src/spotpy/algorithms/abc.py
@@ -79,7 +79,7 @@ class abc(_algorithm):
         """
         self.set_repetiton(repetitions)
         print(
-            "Starting the ABC algotrithm with " + str(repetitions) + " repetitions..."
+            "Starting the ABC algorithm with " + str(repetitions) + " repetitions..."
         )
         # Initialize ABC parameters:
         randompar = self.parameter()["random"]

--- a/src/spotpy/algorithms/dds.py
+++ b/src/spotpy/algorithms/dds.py
@@ -282,7 +282,7 @@ class dds(_algorithm):
             self.parameter()["maxbound"],
         )
         print(
-            "Starting the DDS algotrithm with " + str(repetitions) + " repetitions..."
+            "Starting the DDS algorithm with " + str(repetitions) + " repetitions..."
         )
 
         number_of_parameters = (

--- a/src/spotpy/algorithms/dds.py
+++ b/src/spotpy/algorithms/dds.py
@@ -281,9 +281,7 @@ class dds(_algorithm):
             self.parameter()["minbound"],
             self.parameter()["maxbound"],
         )
-        print(
-            "Starting the DDS algorithm with " + str(repetitions) + " repetitions..."
-        )
+        print(f"Starting the DDS algorithm with {repetitions} repetitions...")
 
         number_of_parameters = (
             self.status.parameters
@@ -389,12 +387,14 @@ class dds(_algorithm):
                 (
                     rep,
                     [
-                        self.np_random.randint(
-                            int(self.min_bound[j]), int(self.max_bound[j]) + 1
+                        (
+                            self.np_random.randint(
+                                int(self.min_bound[j]), int(self.max_bound[j]) + 1
+                            )
+                            if discrete_flag[j]
+                            else self.min_bound[j]
+                            + parameter_bound_range[j] * self.np_random.rand()
                         )
-                        if discrete_flag[j]
-                        else self.min_bound[j]
-                        + parameter_bound_range[j] * self.np_random.rand()
                         for j in range(number_of_parameters)
                     ],
                 )
@@ -471,8 +471,8 @@ class dds(_algorithm):
                 self.min_bound[dec_var],
                 self.max_bound[dec_var],
             )
-            new_x_curr[
-                dec_var
-            ] = new_value  # change relevant decision variable value in s_test
+            new_x_curr[dec_var] = (
+                new_value  # change relevant decision variable value in s_test
+            )
 
         return new_x_curr

--- a/src/spotpy/algorithms/demcz.py
+++ b/src/spotpy/algorithms/demcz.py
@@ -91,9 +91,9 @@ class demcz(_algorithm):
             * False: Simulationt results will not be saved
         """
         kwargs["optimization_direction"] = "maximize"
-        kwargs[
-            "algorithm_name"
-        ] = "Differential Evolution Markov Chain (DE-MC) algorithm"
+        kwargs["algorithm_name"] = (
+            "Differential Evolution Markov Chain (DE-MC) algorithm"
+        )
         super(demcz, self).__init__(*args, **kwargs)
 
     def check_par_validity(self, par):

--- a/src/spotpy/algorithms/demcz.py
+++ b/src/spotpy/algorithms/demcz.py
@@ -144,7 +144,7 @@ class demcz(_algorithm):
 
         self.set_repetiton(repetitions)
         print(
-            "Starting the DEMCz algotrithm with " + str(repetitions) + " repetitions..."
+            "Starting the DEMCz algorithm with " + str(repetitions) + " repetitions..."
         )
 
         self.min_bound, self.max_bound = (

--- a/src/spotpy/algorithms/dream.py
+++ b/src/spotpy/algorithms/dream.py
@@ -54,9 +54,9 @@ class dream(_algorithm):
         """
 
         kwargs["optimization_direction"] = "maximize"
-        kwargs[
-            "algorithm_name"
-        ] = "DiffeRential Evolution Adaptive Metropolis (DREAM) algorithm"
+        kwargs["algorithm_name"] = (
+            "DiffeRential Evolution Adaptive Metropolis (DREAM) algorithm"
+        )
         super(dream, self).__init__(*args, **kwargs)
 
     def check_par_validity_bound(self, par):

--- a/src/spotpy/algorithms/dream.py
+++ b/src/spotpy/algorithms/dream.py
@@ -270,7 +270,7 @@ class dream(_algorithm):
     ):
         self.set_repetiton(repetitions)
         print(
-            "Starting the DREAM algotrithm with " + str(repetitions) + " repetitions..."
+            "Starting the DREAM algorithm with " + str(repetitions) + " repetitions..."
         )
         if nChains < 2 * delta + 1:
             print("Please use at least n=2*delta+1 chains!")

--- a/src/spotpy/algorithms/efast.py
+++ b/src/spotpy/algorithms/efast.py
@@ -8,17 +8,17 @@ It therefore requieres considreably less model runs (for 5 Parameters 2245 (fast
 
 For further information on the functions, the origninal R package and the fast algorithm please have a look at the R package description from CRAN, or see the following references:
 
-Reusser, Dominik E., Wouter Buytaert, and Erwin Zehe. 
+Reusser, Dominik E., Wouter Buytaert, and Erwin Zehe.
 "Temporal dynamics of model parameter sensitivity for computationally expensive models with FAST (Fourier Amplitude Sensitivity Test)." Water Resources Research 47 (2011): W07551.
 
 Further References:
-CUKIER, R. I.; LEVINE, H. B. & SHULER, K. E. Non-Linear 
+CUKIER, R. I.; LEVINE, H. B. & SHULER, K. E. Non-Linear
 "Sensitivity Analysis Of Multi-Parameter Model Systems" Journal Of Computational Physics, 1978 , 26 , 1-42
-CUKIER, R. I.; FORTUIN, C. M.; SHULER, K. E.; PETSCHEK, A. G. & SCHAIBLY, J. H. 
+CUKIER, R. I.; FORTUIN, C. M.; SHULER, K. E.; PETSCHEK, A. G. & SCHAIBLY, J. H.
 "Study Of Sensitivity Of Coupled Reaction Systems To Uncertainties In Rate Coefficients .1. Theory" Journal Of Chemical Physics, 1973 , 59 , 3873-3878
-SCHAIBLY, J. H. & SHULER, K. E. 
+SCHAIBLY, J. H. & SHULER, K. E.
 "Study Of Sensitivity Of Coupled Reaction Systems To Uncertainties In Rate Coefficients .2. Applications" Journal Of Chemical Physics, 1973 , 59 , 3879-3888
-CUKIER, R. I.; SCHAIBLY, J. H. & SHULER, K. E. 
+CUKIER, R. I.; SCHAIBLY, J. H. & SHULER, K. E.
 "Study Of Sensitivity Of Coupled Reaction Systems To Uncertainties In Rate Coefficients .3. Analysis Of Approximations" Journal Of Chemical Physics, 1975 , 63 , 1140-1149
 
 
@@ -39,7 +39,7 @@ class efast(_algorithm):
     """
     EFAST Algorithm for (distributed) parameter Sensitivity after FAST algorithm according to Cukier 1975 or McRae 1982
     The extended Fourier Amplitude Sensitivity Test (eFAST) is a method to determine global sensitvities of a model on parameter changes
-    within relatively few model runs over time. 
+    within relatively few model runs over time.
     """
 
     _unaccepted_parameter_types = ()
@@ -77,23 +77,22 @@ class efast(_algorithm):
             * False: Simulation results will not be saved
         """
 
-        
-
         kwargs["algorithm_name"] = "EFast Sampler"
         super(efast, self).__init__(*args, **kwargs)
 
     # hard coded repetition and frequency values from R package Fast
+    # fmt: off
     d_m_cukier75 = [4,8,6,10,20,22,32,40,38,26,56,62,46,76,96,60,86,126,134,112,92,128,154,196,34,416,106,208,328,198,382,88,348,186,140,170,284,568,302,438,410,248,448,388,596,217,100,488,166]
     min_runs_cukier75 = [np.nan, np.nan, 19, 39, 71, 91, 167, 243, 315, 403, 487, 579, 687, 907, 1019, 1223, 1367, 1655, 1919, 2087, 2351, 2771, 3087, 3427, 3555, 4091, 4467, 4795, 5679, 5763, 6507, 7103, 7523, 8351, 9187, 9667, 10211, 10775, 11339, 7467, 12891, 13739, 14743, 15743, 16975, 18275, 18927, 19907, 20759, 21803]
     omega_m_cukier75 = [np.nan, np.nan, 1, 5, 11, 1, 17, 23, 19, 25, 41, 31, 23, 87, 67, 73, 58, 143, 149, 99, 119, 237, 267, 283, 151, 385, 157, 215, 449, 163, 337, 253, 375, 441, 673, 773, 875, 873, 587, 849, 623, 637, 891, 943, 1171, 1225, 1335, 1725, 1663, 2019]
     d_m_mcrae82 = [4, 8, 6, 10, 20, 22, 32, 40, 38, 26, 56, 62, 46, 76, 96]
     min_runs_mcrae82 = [0, 15, 27, 47, 79, 99, 175, 251, 323, 411, 495, 587, 695, 915, 1027]
     omega_m_mcrae82 = [0, 3, 1, 5, 11, 1, 17, 23, 19, 25, 41, 31, 23, 87, 67]
+    # fmt: on
 
-    def freq_cukier(self, m, i = 1, omega_before = -1):
-    
+    def freq_cukier(self, m, i=1, omega_before=-1):
         """
-        This function creates an array of independant frequencies accroding to 
+        This function creates an array of independent frequencies according to
         Cukier 1975 for usage in the eFAST method.
 
         Parameters
@@ -107,14 +106,14 @@ class efast(_algorithm):
 
         Raises
         ----------
-        Exeption:
+        Exception:
             "Parameter number m to high, not implemented"
-            Execution is stopped, if the number of Parameters is to high (max. Number of Parameters for Cukier = 50)    
+            Execution is stopped, if the number of Parameters is too high (max. Number of Parameters for Cukier = 50)
 
         Returns
         ----------
         np.array of float:
-            A 1d-Array of independant frequencies to the order of 4
+            A 1d-Array of independent frequencies to the order of 4
 
         Author
         ----------
@@ -125,22 +124,20 @@ class efast(_algorithm):
 
         if i <= 1:
             if m >= len(self.omega_m_cukier75):
-                raise Exception("Parameter number m to high, not implemented") 
+                raise Exception("Parameter number m is too high, not implemented")
             else:
-                o = self.omega_m_cukier75[m-1]
-                return np.append(o, self.freq_cukier(m, i+1, o))
+                o = self.omega_m_cukier75[m - 1]
+                return np.append(o, self.freq_cukier(m, i + 1, o))
         else:
-            o = omega_before + self.d_m_cukier75[m-i]
+            o = omega_before + self.d_m_cukier75[m - i]
             if i == m:
                 return o
             else:
-                return np.append(o, self.freq_cukier(m, i+1, o))
-        
+                return np.append(o, self.freq_cukier(m, i + 1, o))
 
-    def freq_mcrae82(self, m, i = 1, omega_before = -1):
-    
+    def freq_mcrae82(self, m, i=1, omega_before=-1):
         """
-        This function creates an array of independant frequencies accroding to 
+        This function creates an array of independent frequencies according to
         McRae 1982 for usage in the eFAST method.
 
         Parameters
@@ -154,14 +151,14 @@ class efast(_algorithm):
 
         Raises
         ----------
-        Exeption:
+        Exception:
             "Parameter number m to high, not implemented"
-            Execution is stopped, if the number of Parameters is to high (max. Number of Parameters for McRae = 15)    
+            Execution is stopped, if the number of Parameters is to high (max. Number of Parameters for McRae = 15)
 
         Returns
         ----------
         np.array of float:
-            A 1d-Array of independant frequencies to the order of 4
+            A 1d-Array of independent frequencies to the order of 4
 
         Author
         ----------
@@ -172,22 +169,20 @@ class efast(_algorithm):
 
         if i <= 1:
             if m >= len(self.omega_m_mcrae82):
-                raise Exception("Parameter number m to high, not implemented") 
+                raise Exception("Parameter number m is too high, not implemented")
             else:
-                o = self.omega_m_mcrae82[m-1]
-                return np.append(o, self.freq_mcrae82(m, i+1, o))
+                o = self.omega_m_mcrae82[m - 1]
+                return np.append(o, self.freq_mcrae82(m, i + 1, o))
         else:
-            o = omega_before + self.d_m_mcrae82[m-i]
+            o = omega_before + self.d_m_mcrae82[m - i]
             if i == m:
                 return o
             else:
-                return np.append(o, self.freq_mcrae82(m, i+1, o))
-        
+                return np.append(o, self.freq_mcrae82(m, i + 1, o))
 
-    def s(self, m, freq = 'cukier'):
-
+    def s(self, m, freq="cukier"):
         """
-        Function that generates a number of equally spaced values between -p1/2 
+        Function that generates a number of equally spaced values between -p1/2
         and pi/2. The number is determined by the number of runs required of the
         eFAST method for a number of parameters (min_runs_cukier or min_runs_mcrae)
 
@@ -218,25 +213,25 @@ class efast(_algorithm):
 
         """
 
-        if freq == 'cukier':
+        if freq == "cukier":
             min_runs = self.min_runs_cukier75
-        elif freq == 'mcrae':
+        elif freq == "mcrae":
             min_runs = self.min_runs_mcrae82
         else:
-            raise Exception("Missing option for Frequency selection for Parameter definition, choose cukier or mcrae!")
-        
-        r = min_runs[m-1]
-        r_range = np.array(range(1,r+1))
-        s = np.pi/r * (2*r_range-r-1)/2
-    
+            raise Exception(
+                "Missing option for Frequency selection for Parameter definition, choose cukier or mcrae!"
+            )
+
+        r = min_runs[m - 1]
+        r_range = np.array(range(1, r + 1))
+        s = np.pi / r * (2 * r_range - r - 1) / 2
+
         return s
 
-
-    def S(self, m, freq = 'cukier'):
-    
+    def S(self, m, freq="cukier"):
         """
-        Function to generate an array of values, which provides the base for the parameterdistribution 
-        in the FAST method. It is usally not used directly but called from the 
+        Function to generate an array of values, which provides the base for the parameterdistribution
+        in the FAST method. It is usually not used directly but called from the
         fast_parameters function.
 
         Parameters
@@ -250,7 +245,7 @@ class efast(_algorithm):
 
         Raises
         ----------
-        Exeption:
+        Exception:
             "Missing option for Frequency selection for Parameter definition, choose cukier or mcrae!"
             Execution is stopped if an invalid method for the frequency selection is provided
 
@@ -265,24 +260,24 @@ class efast(_algorithm):
         spotpy translation: Anna Herzog
         """
 
-        if freq == 'cukier':
+        if freq == "cukier":
             omega = self.freq_cukier(m)
-        elif freq == 'mcrae':
+        elif freq == "mcrae":
             omega = self.freq_mcrae82(m)
         else:
-            raise Exception("Missing option for Frequency selection for Parameter definition, choose cukier or mcrae!")
-    
+            raise Exception(
+                "Missing option for Frequency selection for Parameter definition, choose cukier or mcrae!"
+            )
+
         tab = np.outer(self.s(m, freq), omega)
-    
-        toreturn = np.arcsin(np.sin(tab))/np.pi
-    
+
+        toreturn = np.arcsin(np.sin(tab)) / np.pi
+
         # naming array dimensions is not possible with numpy but convention would be toreturn.shape () = (runs, parameternames)
-    
+
         return toreturn
 
-
-    def rerange(self, data, min_goal = 0, max_goal = 1, center = np.nan):
-
+    def rerange(self, data, min_goal=0, max_goal=1, center=np.nan):
         """
         This function performes a linear transformation of the data, such that
         afterwards range(data) = (theMin, theMax)
@@ -309,40 +304,56 @@ class efast(_algorithm):
         ----------
         Dominic Reusser
         spotpy translation: Anna Herzog
-    
+
         """
-    
+
         min_data = min(data)
         max_data = max(data)
-    
+
         if np.isnan(center):
             max_data = max_data
             dat = data - min_data
-            dat = dat/(max_data-min_data) * (max_goal-min_goal)
+            dat = dat / (max_data - min_data) * (max_goal - min_goal)
             dat = dat + min_goal
-            return(dat)
+            return dat
         else:
-            # split linear transformation, the data is split into two segments, one blow center, one above, 
-            # each segment undergoes it's own linear transformation
+            # split linear transformation, the data is split into two segments, one blow center, one above,
+            # each segment undergoes its own linear transformation
             below = data <= center
             above = data > center
             new_data = np.copy(data)
-            np.place(new_data, below, self.rerange(np.insert(data[below], 0, center), min_goal = min_goal, max_goal= max_goal/2)[1:])
-            np.place(new_data, above, self.rerange(np.insert(data[above], 0, center), min_goal = max_goal/2, max_goal= max_goal)[1:])
-            return(new_data)
-    
+            np.place(
+                new_data,
+                below,
+                self.rerange(
+                    np.insert(data[below], 0, center),
+                    min_goal=min_goal,
+                    max_goal=max_goal / 2,
+                )[1:],
+            )
+            np.place(
+                new_data,
+                above,
+                self.rerange(
+                    np.insert(data[above], 0, center),
+                    min_goal=max_goal / 2,
+                    max_goal=max_goal,
+                )[1:],
+            )
+            return new_data
 
-    def fast_parameters(self, minimum, maximum, freq = 'cukier', logscale = np.nan, names = np.nan):
-    
+    def fast_parameters(
+        self, minimum, maximum, freq="cukier", logscale=np.nan, names=np.nan
+    ):
         """
-        Function for the creation of a FAST Parameter set based on thier range
+        Function for the creation of a FAST Parameter set based on their range
 
         Parameters
         ----------
-        minimum: array of float 
-            array containing the lower parameter boundries
-        maximum: array of float 
-            array containing the upper parameter boundries
+        minimum: array of float
+            array containing the lower parameter boundaries
+        maximum: array of float
+            array containing the upper parameter boundaries
         names: (optional) str
             array containing the parameter names
         freq: (optional) str
@@ -354,14 +365,14 @@ class efast(_algorithm):
 
         Raises
         ----------
-        Exeption:
+        Exception:
             "Expecting minimum and maximum of same size"
             Execution is stopped if the number of minimum, maximum or logscale values differ
 
         Returns
         ----------
         value: array of float
-            an array with the shape (number of runs, parameters) containing the 
+            an array with the shape (number of runs, parameters) containing the
             required parameter sets
 
         Author
@@ -370,33 +381,32 @@ class efast(_algorithm):
         spotpy translation: Anna Herzog
 
         """
-        
+
         if np.isnan(logscale):
             logscale = np.full(minimum.shape, False)
         if np.isnan(names):
-            names = ["P"+str(i) for i in range(minimum.shape[0])]
-            names = np.array(names)  
-    
+            names = ["P" + str(i) for i in range(minimum.shape[0])]
+            names = np.array(names)
+
         n = len(minimum)
-    
-        if (n != len(maximum)):
-            raise Exception("Expecting minimum and maximum of same size") 
-        elif(n != len(names)):
-            raise Exception("Expecting minimum and names of same size") 
-        elif(n != len(logscale)):
-            raise Exception("Expecting minimum and logscale of same size") 
-    
-        toreturn = self.S(m=n, freq = freq) #par_names = names, 
-    
-        for i in range(0,n):
-            toreturn[:,i] = self.rerange(toreturn[:,i], minimum[i], maximum[i])
+
+        if n != len(maximum):
+            raise Exception("Expecting minimum and maximum of same size")
+        elif n != len(names):
+            raise Exception("Expecting minimum and names of same size")
+        elif n != len(logscale):
+            raise Exception("Expecting minimum and logscale of same size")
+
+        toreturn = self.S(m=n, freq=freq)  # par_names = names,
+
+        for i in range(0, n):
+            toreturn[:, i] = self.rerange(toreturn[:, i], minimum[i], maximum[i])
             if logscale[i]:
-                toreturn[:,i] = 10**toreturn[:,i]
-            
+                toreturn[:, i] = 10 ** toreturn[:, i]
+
         return toreturn
 
-
-    def sample(self, repetitions, freq = 'cukier', logscale = np.nan):
+    def sample(self, repetitions, freq="cukier", logscale=np.nan):
         """
         Samples from the eFAST algorithm.
 
@@ -415,21 +425,21 @@ class efast(_algorithm):
         ----------
         Warning:
             "specified number of repetitions is smaller than minimum required for eFAST analysis!
-            Simultions will be perfomed but eFAST analysis might not be possible"
+            Simulations will be performed but eFAST analysis might not be possible"
 
             If the specified number of repetitions is smaller than required by the algorithm, the
-            algortihm will still execute, but the usage of spotpy.analyser.efast.calc_sensitivity() 
+            algorithm will still execute, but the usage of spotpy.analyser.efast.calc_sensitivity()
             might not be possible. Rather define a large number of reps as only required minimum runs
-            will be performed anyway. 
-        
+            will be performed anyway.
+
         Warning:
-            "Number of specified repetitions equals or exeeds number of minimum required repetitions for eFAST analysis
-             programm will stop after required runs."
+            "Number of specified repetitions equals or exceeds number of minimum required repetitions for eFAST analysis
+             program will stop after required runs."
 
         Returns
         ----------
         database:
-            spotpy data base in chosen format with objective function values, parameter values and simulation results
+            spotpy database in chosen format with objective function values, parameter values and simulation results
 
         Author
         ----------
@@ -443,15 +453,19 @@ class efast(_algorithm):
         # distribution
         parmin, parmax = self.parameter()["minbound"], self.parameter()["maxbound"]
         self.numberf = len(parmin)
-        min_runs = self.min_runs_cukier75[self.numberf-1]
+        min_runs = self.min_runs_cukier75[self.numberf - 1]
 
         if min_runs > repetitions:
-            warnings.warn("specified number of repetitions is smaller than minimum required for eFAST analysis!\n"+
-                          "Simultions will be perfomed but eFAST analysis might not be possible")
+            warnings.warn(
+                "specified number of repetitions is smaller than minimum required for eFAST analysis!\n"
+                "Simulations will be performed but eFAST analysis might not be possible"
+            )
         else:
             repetitions = min_runs
-            print("Number of specified repetitions equals or exeeds number of minimum required repetitions for eFAST analysis\n"+
-                  "programm will stop after required runs.")
+            print(
+                "Number of specified repetitions equals or exceeds number of minimum required repetitions for eFAST analysis\n"
+                "program will stop after required runs."
+            )
 
         self.set_repetiton(repetitions)
 
@@ -461,23 +475,21 @@ class efast(_algorithm):
         print("Starting the eFast algorithm with {} repetitions...".format(repetitions))
 
         # A generator that produces parametersets if called
-        param_generator = (
-            (rep, N[rep,:]) for rep in range(int(repetitions))
-        )
+        param_generator = ((rep, N[rep, :]) for rep in range(int(repetitions)))
         for rep, randompar, simulations in self.repeat(param_generator):
             # A function that calculates the fitness of the run and the manages the database
             self.postprocessing(rep, randompar, simulations)
 
             if self.breakpoint == "write" or self.breakpoint == "readandwrite":
                 if rep >= lastbackup + self.backup_every_rep:
-                    work = (rep, N[rep,:])
+                    work = (rep, N[rep, :])
                     self.write_breakdata(self.dbname, work)
                     lastbackup = rep
         self.final_call()
 
-    def calc_sensitivity(self, results, dbname, freq = 'cukier'):
+    def calc_sensitivity(self, results, dbname, freq="cukier"):
         """
-        Function to calcultae the sensitivity for a data series (eg. a time series) 
+        Function to calculate the sensitivity for a data series (e.g. a time series)
         based on the eFAST algorithm.
 
         Parameters
@@ -485,7 +497,7 @@ class efast(_algorithm):
         results: np.array of void
             spopty restults array as loaded with spotpy.analyser.load_csv_results()
         dbname: (optional) str
-            name of file to store sensitivity values        
+            name of file to store sensitivity values
         freq: (optional) str
             indicates weather to use the frequencies after Cukier 'cukier' or McRae 'mcrae'
             Default is Cukier
@@ -500,54 +512,56 @@ class efast(_algorithm):
         ----------
         database:
             database containing the temporal parameter sensitivities with seperate column
-            for each parameter and row for eg. time step
+            for each parameter and row for e.g. time step
 
         Author
         ----------
         Dominic Reusser
         spotpy translation: Anna Herzog
-    
-        """ 
+
+        """
         numberf = len(self.parameter()["minbound"])
 
         # sens_data = np.full((len(results[0]), numberf), np.nan)
-        
+
         # idendtify frequency
-        if freq == 'cukier':
-            t_runs = self.min_runs_cukier75[numberf-1]
+        if freq == "cukier":
+            t_runs = self.min_runs_cukier75[numberf - 1]
             t_freq = self.freq_cukier(numberf)
-        elif freq == 'mcrae': 
-            t_runs = self.min_runs_mcrae82[numberf-1]
+        elif freq == "mcrae":
+            t_runs = self.min_runs_mcrae82[numberf - 1]
             t_freq = self.freq_mcrae82(numberf)
         else:
-            raise Exception("Missing option for Frequency selection for Parameter definition, choose cukier or mcrae!")
-    
+            raise Exception(
+                "Missing option for Frequency selection for Parameter definition, choose cukier or mcrae!"
+            )
+
         # Get the names of the parameters to analyse
         names = ["par" + name for name in self.parameter()["name"]]
 
         # open the file for sensitivity results
-        f = open(dbname+".csv", 'w+')
+        f = open(f"{dbname}.csv", "w+")
         np.savetxt(f, [names], "%s", delimiter=",")
-        
+
         data = np.array(results)
-        
-        try:            
+
+        try:
             # convert array of void to array of float
             mod_results = np.full((data.shape[0], len(data[0])), np.nan)
 
-            for index in range(len(data)):        
+            for index in range(len(data)):
                 mod_results[index, :] = list(data[index])
-      
+
             print("data series")
-            for index in range(mod_results.shape[1]):    
+            for index in range(mod_results.shape[1]):
                 x_data = mod_results[:, index]
                 sens_data = efast_sensitivity(x_data, numberf, t_runs, t_freq)
-                np.savetxt(f, [sens_data], delimiter=",", fmt='%1.5f')
-                
+                np.savetxt(f, [sens_data], delimiter=",", fmt="%1.5f")
+
         except:
             print("single data")
             x_data = data
             sens_data = efast_sensitivity(x_data, numberf, t_runs, t_freq)
-            np.savetxt(f, [sens_data], delimiter=",", fmt='%1.5f')
-        
+            np.savetxt(f, [sens_data], delimiter=",", fmt="%1.5f")
+
         f.close()

--- a/src/spotpy/algorithms/fast.py
+++ b/src/spotpy/algorithms/fast.py
@@ -204,7 +204,7 @@ class fast(_algorithm):
         """
         self.set_repetiton(repetitions)
         print(
-            "Starting the FAST algotrithm with " + str(repetitions) + " repetitions..."
+            "Starting the FAST algorithm with " + str(repetitions) + " repetitions..."
         )
         print("Creating FAST Matrix")
         # Get the names of the parameters to analyse

--- a/src/spotpy/algorithms/fscabc.py
+++ b/src/spotpy/algorithms/fscabc.py
@@ -59,9 +59,9 @@ class fscabc(_algorithm):
             * False: Simulation results will not be saved
         """
         kwargs["optimization_direction"] = "maximize"
-        kwargs[
-            "algorithm_name"
-        ] = "Fitness Scaled Chaotic Artificial Bee Colony (FSCABC) algorithm"
+        kwargs["algorithm_name"] = (
+            "Fitness Scaled Chaotic Artificial Bee Colony (FSCABC) algorithm"
+        )
         super(fscabc, self).__init__(*args, **kwargs)
 
     def mutate(self, r):
@@ -87,9 +87,7 @@ class fscabc(_algorithm):
         """
         self.set_repetiton(repetitions)
         print(
-            "Starting the FSCABC algorithm with "
-            + str(repetitions)
-            + " repetitions..."
+            f"Starting the FSCABC algorithm with {repetitions} repetitions..."
         )
         # Initialize FSCABC parameters:
         parset = self.parameter()

--- a/src/spotpy/algorithms/fscabc.py
+++ b/src/spotpy/algorithms/fscabc.py
@@ -86,9 +86,7 @@ class fscabc(_algorithm):
             sets the limit for scout bee phase
         """
         self.set_repetiton(repetitions)
-        print(
-            f"Starting the FSCABC algorithm with {repetitions} repetitions..."
-        )
+        print(f"Starting the FSCABC algorithm with {repetitions} repetitions...")
         # Initialize FSCABC parameters:
         parset = self.parameter()
         randompar = parset["random"]

--- a/src/spotpy/algorithms/fscabc.py
+++ b/src/spotpy/algorithms/fscabc.py
@@ -87,7 +87,7 @@ class fscabc(_algorithm):
         """
         self.set_repetiton(repetitions)
         print(
-            "Starting the FSCABC algotrithm with "
+            "Starting the FSCABC algorithm with "
             + str(repetitions)
             + " repetitions..."
         )

--- a/src/spotpy/algorithms/lhs.py
+++ b/src/spotpy/algorithms/lhs.py
@@ -62,7 +62,7 @@ class lhs(_algorithm):
         """
         self.set_repetiton(repetitions)
         print(
-            "Starting the LHS algotrithm with " + str(repetitions) + " repetitions..."
+            "Starting the LHS algorithm with " + str(repetitions) + " repetitions..."
         )
         print("Creating LatinHyperCube Matrix")
         # Get the names of the parameters to analyse

--- a/src/spotpy/algorithms/lhs.py
+++ b/src/spotpy/algorithms/lhs.py
@@ -61,9 +61,7 @@ class lhs(_algorithm):
             maximum number of function evaluations allowed during optimization
         """
         self.set_repetiton(repetitions)
-        print(
-            "Starting the LHS algorithm with " + str(repetitions) + " repetitions..."
-        )
+        print(f"Starting the LHS algorithm with {repetitions} repetitions...")
         print("Creating LatinHyperCube Matrix")
         # Get the names of the parameters to analyse
         names = self.parameter()["name"]

--- a/src/spotpy/algorithms/mcmc.py
+++ b/src/spotpy/algorithms/mcmc.py
@@ -98,7 +98,7 @@ class mcmc(_algorithm):
     def sample(self, repetitions, nChains=1):
         self.set_repetiton(repetitions)
         print(
-            "Starting the MCMC algotrithm with " + str(repetitions) + " repetitions..."
+            "Starting the MCMC algorithm with " + str(repetitions) + " repetitions..."
         )
         # Prepare storing MCMC chain as array of arrays.
         self.nChains = int(nChains)

--- a/src/spotpy/algorithms/mle.py
+++ b/src/spotpy/algorithms/mle.py
@@ -64,9 +64,7 @@ class mle(_algorithm):
 
     def sample(self, repetitions):
         self.set_repetiton(repetitions)
-        print(
-            "Starting the MLE algorithm with " + str(repetitions) + " repetitions..."
-        )
+        print(f"Starting the MLE algorithm with {repetitions} repetitions...")
         # Define stepsize of MLE
         stepsizes = self.parameter()["step"]  # array of stepsizes
         accepted = 0.0

--- a/src/spotpy/algorithms/mle.py
+++ b/src/spotpy/algorithms/mle.py
@@ -65,7 +65,7 @@ class mle(_algorithm):
     def sample(self, repetitions):
         self.set_repetiton(repetitions)
         print(
-            "Starting the MLE algotrithm with " + str(repetitions) + " repetitions..."
+            "Starting the MLE algorithm with " + str(repetitions) + " repetitions..."
         )
         # Define stepsize of MLE
         stepsizes = self.parameter()["step"]  # array of stepsizes

--- a/src/spotpy/algorithms/nsgaii.py
+++ b/src/spotpy/algorithms/nsgaii.py
@@ -179,9 +179,9 @@ class NSGAII(_algorithm):
         """
         self._return_all_likes = True  # alloes multi-objective calibration
         kwargs["optimization_direction"] = "minimize"
-        kwargs[
-            "algorithm_name"
-        ] = "Fast and Elitist Multiobjective Genetic Algorithm: NSGA-II"
+        kwargs["algorithm_name"] = (
+            "Fast and Elitist Multiobjective Genetic Algorithm: NSGA-II"
+        )
         super(NSGAII, self).__init__(*args, **kwargs)
 
     def fastSort(self, x):
@@ -194,9 +194,9 @@ class NSGAII(_algorithm):
                 S[i, j] = self.dominates(x[i, :], x[j, :])
 
         nDom = np.sum(S, axis=0)  # the n solutions that dominates i
-        Np[
-            nDom == 0
-        ] = 1  # if i ==  0, i is non-dominated, set i rank to 1, i belongs to first non-dominated front
+        Np[nDom == 0] = (
+            1  # if i ==  0, i is non-dominated, set i rank to 1, i belongs to first non-dominated front
+        )
         k = 1
         # loop over pareto fronts
         while np.sum(Np == 0) > 0:

--- a/src/spotpy/algorithms/padds.py
+++ b/src/spotpy/algorithms/padds.py
@@ -248,7 +248,7 @@ class padds(_algorithm):
         # Spotpy will not need this values.
         debug_results = []
         print(
-            "Starting the PADDS algotrithm with " + str(repetitions) + " repetitions..."
+            "Starting the PADDS algorithm with " + str(repetitions) + " repetitions..."
         )
         print(
             "WARNING: THE PADDS algorithm as implemented in SPOTPY is in an beta stage and not ready for production use!"

--- a/src/spotpy/algorithms/padds.py
+++ b/src/spotpy/algorithms/padds.py
@@ -101,9 +101,9 @@ class padds(_algorithm):
 
         self._return_all_likes = True  # allows multi-objective calibration
         kwargs["optimization_direction"] = "minimize"
-        kwargs[
-            "algorithm_name"
-        ] = "Pareto Archived Dynamically Dimensioned Search (PADDS) algorithm"
+        kwargs["algorithm_name"] = (
+            "Pareto Archived Dynamically Dimensioned Search (PADDS) algorithm"
+        )
 
         super(padds, self).__init__(*args, **kwargs)
 
@@ -162,6 +162,7 @@ class padds(_algorithm):
             yield rep, self.calculate_next_s_test(
                 self.best_value.parameters, rep, self.generator_repetitions, self.r
             )
+
     def calculate_initial_parameterset(self, repetitions, initial_objs, initial_params):
         self.obj_func_current = np.array([0.0])
         self.parameter_current = np.array([0.0] * self.number_of_parameters)
@@ -170,23 +171,23 @@ class padds(_algorithm):
         )
         self.pareto_front = [
             np.zeros(self.number_of_parameters),
-            np.zeros(self.number_of_parameters)
+            np.zeros(self.number_of_parameters),
         ]
         print(self.pareto_front)
         self.pareto_front = np.array(self.pareto_front)
-    # def calculate_initial_parameterset(self, repetitions, initial_objs, initial_params):
-    #     self.obj_func_current = np.array([0.0])
-    #     self.parameter_current = np.array([0.0] * self.number_of_parameters)
-    #     self.parameter_range = (
-    #         self.best_value.parameters.maxbound - self.best_value.parameters.minbound
-    #     )
-    #     self.pareto_front = [
-    #     np.array([]),
-    #     np.zeros(self.number_of_parameters)
-    #     ]
-    #     # self.pareto_front = np.array(
-    #     #     [[np.array([]), np.array([0] * self.number_of_parameters)]]
-    #     # )
+        # def calculate_initial_parameterset(self, repetitions, initial_objs, initial_params):
+        #     self.obj_func_current = np.array([0.0])
+        #     self.parameter_current = np.array([0.0] * self.number_of_parameters)
+        #     self.parameter_range = (
+        #         self.best_value.parameters.maxbound - self.best_value.parameters.minbound
+        #     )
+        #     self.pareto_front = [
+        #     np.array([]),
+        #     np.zeros(self.number_of_parameters)
+        #     ]
+        #     # self.pareto_front = np.array(
+        #     #     [[np.array([]), np.array([0] * self.number_of_parameters)]]
+        #     # )
 
         # self.pareto_front = np.array([np.append([np.inf] * self.like_struct_len, [0] * self.number_of_parameters)])
 
@@ -438,9 +439,9 @@ class padds(_algorithm):
                 self.max_bound[dec_var - 1],
             )
 
-            new_x_curr[
-                dec_var - 1
-            ] = new_value  # change relevant decision variable value in s_test
+            new_x_curr[dec_var - 1] = (
+                new_value  # change relevant decision variable value in s_test
+            )
         return new_x_curr
 
 

--- a/src/spotpy/algorithms/rope.py
+++ b/src/spotpy/algorithms/rope.py
@@ -107,7 +107,7 @@ class rope(_algorithm):
         # wenn mehr parameter produziert werden sollen als reingehen, rechnet er sich tot (ngen>n)
         # Subsets < 5 führt manchmal zu Absturz
         print(
-            "Starting the ROPE algotrithm with " + str(repetitions) + " repetitions..."
+            "Starting the ROPE algorithm with " + str(repetitions) + " repetitions..."
         )
         self.set_repetiton(repetitions)
 

--- a/src/spotpy/algorithms/rope.py
+++ b/src/spotpy/algorithms/rope.py
@@ -23,7 +23,6 @@ class rope(_algorithm):
     """
 
     def __init__(self, *args, **kwargs):
-
         """
         Input
         ----------
@@ -54,7 +53,7 @@ class rope(_algorithm):
             * seq: Sequentiel sampling (default): Normal iterations on one core
             of your cpu.
             * mpc: Multi processing: Iterations on all available cores on your cpu
-            (recommended for windows os).
+            (recommended for Windows os).
             * mpi: Message Passing Interface: Parallel computing on cluster pcs
             (recommended for unix os).
 

--- a/src/spotpy/algorithms/sa.py
+++ b/src/spotpy/algorithms/sa.py
@@ -75,7 +75,7 @@ class sa(_algorithm):
             Maximum number of runs.
         """
         self.set_repetiton(repetitions)
-        print("Starting the SA algotrithm with " + str(repetitions) + " repetitions...")
+        print("Starting the SA algorithm with " + str(repetitions) + " repetitions...")
         self.min_bound, self.max_bound = (
             self.parameter()["minbound"],
             self.parameter()["maxbound"],

--- a/src/spotpy/analyser.py
+++ b/src/spotpy/analyser.py
@@ -129,6 +129,7 @@ def get_modelruns(results):
     fields = [word for word in results.dtype.names if word.startswith("sim")]
     return results[fields]
 
+
 def get_modelruns_list(results):
     """
     Get a list of shorter arrays out of your result array, containing just the
@@ -143,20 +144,25 @@ def get_modelruns_list(results):
 
     fields = [word for word in results.dtype.names if word.startswith("sim")]
     fields_sim = [field.split("_")[0] for field in fields]
-    sim_nr = [int(num) for s in fields_sim for num in ''.join([c if c.isdigit() else ' ' for c in s]).split()]
+    sim_nr = [
+        int(num)
+        for s in fields_sim
+        for num in "".join([c if c.isdigit() else " " for c in s]).split()
+    ]
     try:
         max_simnr = max(sim_nr)
 
         results_x = list()
         for i in range(max_simnr):
-            fields_i = [word for word in results.dtype.names if "n"+str(i+1)+"_" in word]
+            fields_i = [
+                word for word in results.dtype.names if f"n{str(i + 1)}_" in word
+            ]
             results_x.append(results[fields_i])
         return results_x
-    
+
     except ValueError:
         raise ValueError("The model only has one output, use get_modelruns() instead")
 
-    
 
 def get_parameters(results):
     """
@@ -365,8 +371,10 @@ def plot_posterior_parameter_histogram(ax, results, parameter):
 
 
 def plot_parameter_uncertainty(
-    posterior_results, evaluation, maximize=True, 
-    fig_name="Posterior_parameter_uncertainty.png"
+    posterior_results,
+    evaluation,
+    maximize=True,
+    fig_name="Posterior_parameter_uncertainty.png",
 ):
     import matplotlib.pyplot as plt
 
@@ -395,7 +403,7 @@ def plot_parameter_uncertainty(
     if maximize:
         bestindex, bestobjf = get_maxlikeindex(posterior_results, verbose=False)
     else:
-        bestindex, bestobjf = get_minlikeindex(posterior_results, verbose=False)     
+        bestindex, bestobjf = get_minlikeindex(posterior_results, verbose=False)
     plt.plot(
         list(posterior_results[simulation_fields][bestindex][0]),
         "b-",
@@ -1246,10 +1254,11 @@ def _Geweke(samples, intervals=20):
         z[k] = (mean1 - mean2) / np.sqrt(var1 + var2)
     return z
 
+
 def double_serie(x):
     """
     This function reverses the model output series from a number of model runs for
-    the eFAST analysis and appends it to the original series. The last element of the 
+    the eFAST analysis and appends it to the original series. The last element of the
     existing series is not duplicated during this process.
     This is required in order to process the model run results for the FAST
     analysis with the fft function.
@@ -1259,22 +1268,32 @@ def double_serie(x):
     Parameters
     ----------
     x: np.array of float
-        dataseries to be doubled 
+        dataseries to be doubled
 
     Returns
     ----------
     value: np.array of float
-        doubled x 
+        doubled x
 
     Author
     ----------
     Dominic Reusser
-    spotpy translation: Anna Herzog   
+    spotpy translation: Anna Herzog
     """
 
-    return(np.append(x, np.flip(x)[1:]))
+    return np.append(x, np.flip(x)[1:])
 
-def efast_sensitivity(x, numberf, t_runs, t_freq, order = 4, make_plot = False, include_total_variance = False, cukier = True):
+
+def efast_sensitivity(
+    x,
+    numberf,
+    t_runs,
+    t_freq,
+    order=4,
+    make_plot=False,
+    include_total_variance=False,
+    cukier=True,
+):
     """
     function that calculates the sensitivity from a series of model outputs
     according to the eFAST algorithm
@@ -1284,10 +1303,10 @@ def efast_sensitivity(x, numberf, t_runs, t_freq, order = 4, make_plot = False, 
     Parameters
     ----------
     x: np.array of float,
-        1D array of model outputs where parameters vary between runs according to the fast algorithm    
+        1D array of model outputs where parameters vary between runs according to the fast algorithm
     numberf: int
         Number of parameters vaired
-    t_runs: float 
+    t_runs: float
         number of runs required by algorithm (calculated internally in eFAST algorithm)
     t_freq: float
         frequencies used for parameter sampling (calculated internally in eFAST algorithm)
@@ -1298,16 +1317,16 @@ def efast_sensitivity(x, numberf, t_runs, t_freq, order = 4, make_plot = False, 
         plot the Fourier spectrum?
         default = False
     include_total_variance: bool, optional
-        include the sum of all variances in the result array? 
+        include the sum of all variances in the result array?
         default = False
-    
+
     Raises
     ----------
     Exeption:
         "Not enough model runs loaded. Expected <x> runs, but found only <y>"
-        Function is stoped, if the loaded data base contains not enough model 
+        Function is stoped, if the loaded data base contains not enough model
         runs for the given number of parameters. A pervious warning might have
-        appeared during execution of the sample() function. 
+        appeared during execution of the sample() function.
 
     Returns
     ----------
@@ -1317,30 +1336,36 @@ def efast_sensitivity(x, numberf, t_runs, t_freq, order = 4, make_plot = False, 
     Author
     ----------
     Dominic Reusser
-    spotpy translation: Anna Herzog  
+    spotpy translation: Anna Herzog
 
-    """    
-    
+    """
+
     if len(x) < t_runs:
-        raise Exception("Not enough model runs loaded. Expected " + str(t_runs) +" runs, but found only " + str(len(x)))
-        
-    fft = np.fft.fft(double_serie(x))
-    ff = abs(fft/len(x))[:len(x)+1]
-    
-    freq = np.outer(t_freq, range(1, order+1))
-    
-    total = sum(ff[1:,]**2)
+        raise Exception(
+            "Not enough model runs loaded. Expected "
+            + str(t_runs)
+            + " runs, but found only "
+            + str(len(x))
+        )
 
-    sens = np.full(freq.shape[0], np.nan) 
-    
+    fft = np.fft.fft(double_serie(x))
+    ff = abs(fft / len(x))[: len(x) + 1]
+
+    freq = np.outer(t_freq, range(1, order + 1))
+
+    total = sum(ff[1:,] ** 2)
+
+    sens = np.full(freq.shape[0], np.nan)
+
     for i in range(freq.shape[0]):
-        index = freq[i,:][freq[i,:] < len(ff)]
-        sens[i] = np.nansum(ff[index]**2)/total
-        
+        index = freq[i, :][freq[i, :] < len(ff)]
+        sens[i] = np.nansum(ff[index] ** 2) / total
+
     if include_total_variance:
         np.append(sens, total)
-        
+
     return sens
+
 
 def void_to_arr(results):
     """
@@ -1354,22 +1379,22 @@ def void_to_arr(results):
     ----------
     value: np.array of float
     """
-    
+
     arr = np.full((results.shape[0], len(results[0])), np.nan)
-    for index in range(len(results)):        
+    for index in range(len(results)):
         arr[index, :] = list(results[index])
 
     return arr
 
-def plot_efast(dbname, fig_name = "efast_sensitivities.png"):
 
+def plot_efast(dbname, fig_name="efast_sensitivities.png"):
     """
     Function to plot the series of parameter sensitvities generated by the eFAST algorithm
 
     Parameters
     ----------
     dbname: str
-        name of the database with the parameter sensitvities generated by eFAST algorithm 
+        name of the database with the parameter sensitvities generated by eFAST algorithm
     fig_name: (optional) str
         custom name of the figure
 
@@ -1384,12 +1409,11 @@ def plot_efast(dbname, fig_name = "efast_sensitivities.png"):
 
     parameters = senstivities.dtype.names
     sens_values = void_to_arr(senstivities).T
-    
-    fig, axs = plt.subplots(len(parameters), sharey=True)
-    
-    for i in range(len(parameters)):
-        axs[i].plot(range(len(sens_values[i,:])), sens_values[i,:])
-        axs[i].set_ylabel(parameters[i])
-    
-    fig.savefig(fig_name, dpi=150)
 
+    fig, axs = plt.subplots(len(parameters), sharey=True)
+
+    for i in range(len(parameters)):
+        axs[i].plot(range(len(sens_values[i, :])), sens_values[i, :])
+        axs[i].set_ylabel(parameters[i])
+
+    fig.savefig(fig_name, dpi=150)

--- a/src/spotpy/examples/cmf_data/__init__.py
+++ b/src/spotpy/examples/cmf_data/__init__.py
@@ -5,21 +5,21 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 :author: Tobias Houska
 
-:paper: Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.: 
-SPOTting Model Parameters Using a Ready-Made Python Package, 
+:paper: Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.:
+SPOTting Model Parameters Using a Ready-Made Python Package,
 PLoS ONE, 10(12), e0145180, doi:10.1371/journal.pone.0145180, 2015.
 
-This package enables the comprehensive use of different Bayesian and Heuristic calibration 
-techniques in one Framework. It comes along with an algorithms folder for the 
+This package enables the comprehensive use of different Bayesian and Heuristic calibration
+techniques in one Framework. It comes along with an algorithms folder for the
 sampling and an analyser class for the plotting of results by the sampling.
 
-:dependencies: - Numpy >1.8 (http://www.numpy.org/) 
-               - Pandas >0.13 (optional) (http://pandas.pydata.org/)
-               - Matplotlib >1.4 (optional) (http://matplotlib.org/) 
+:dependencies: - Numpy >2 (https://www.numpy.org/)
+               - Pandas >1 (optional) (https://pandas.pydata.org/)
+               - Matplotlib >1.4 (optional) (https://matplotlib.org/)
                - CMF (optional) (http://fb09-pasig.umwelt.uni-giessen.de:8000/)
-               - mpi4py (optional) (http://mpi4py.scipy.org/)
-               - pathos (optional) (https://pypi.python.org/pypi/pathos/)
-               - sqlite3 (optional) (https://pypi.python.org/pypi/sqlite3/)
+               - mpi4py (optional) (https://mpi4py.readthedocs.io/en/stable/)
+               - pathos (optional) (https://pathos.readthedocs.io/en/latest/)
+               - sqlite3 (optional) (https://docs.python.org/3/library/sqlite3.html)
 
                :help: For specific questions, try to use the documentation website at:
                 http://fb09-pasig.umwelt.uni-giessen.de/spotpy/

--- a/src/spotpy/examples/hymod_exe/__init__.py
+++ b/src/spotpy/examples/hymod_exe/__init__.py
@@ -5,21 +5,21 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 :author: Tobias Houska
 
-:paper: Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.: 
-SPOTting Model Parameters Using a Ready-Made Python Package, 
+:paper: Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.:
+SPOTting Model Parameters Using a Ready-Made Python Package,
 PLoS ONE, 10(12), e0145180, doi:10.1371/journal.pone.0145180, 2015.
 
-This package enables the comprehensive use of different Bayesian and Heuristic calibration 
-techniques in one Framework. It comes along with an algorithms folder for the 
+This package enables the comprehensive use of different Bayesian and Heuristic calibration
+techniques in one Framework. It comes along with an algorithms folder for the
 sampling and an analyser class for the plotting of results by the sampling.
 
-:dependencies: - Numpy >1.8 (http://www.numpy.org/) 
-               - Pandas >0.13 (optional) (http://pandas.pydata.org/)
-               - Matplotlib >1.4 (optional) (http://matplotlib.org/) 
+:dependencies: - Numpy >2 (https://www.numpy.org/)
+               - Pandas >1 (optional) (https://pandas.pydata.org/)
+               - Matplotlib >1.4 (optional) (https://matplotlib.org/)
                - CMF (optional) (http://fb09-pasig.umwelt.uni-giessen.de:8000/)
-               - mpi4py (optional) (http://mpi4py.scipy.org/)
-               - pathos (optional) (https://pypi.python.org/pypi/pathos/)
-               - sqlite3 (optional) (https://pypi.python.org/pypi/sqlite3/)
+               - mpi4py (optional) (https://mpi4py.readthedocs.io/en/stable/)
+               - pathos (optional) (https://pathos.readthedocs.io/en/latest/)
+               - sqlite3 (optional) (https://docs.python.org/3/library/sqlite3.html)
 
                :help: For specific questions, try to use the documentation website at:
                 http://fb09-pasig.umwelt.uni-giessen.de/spotpy/

--- a/src/spotpy/examples/hymod_python/__init__.py
+++ b/src/spotpy/examples/hymod_python/__init__.py
@@ -5,21 +5,21 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 :author: Tobias Houska
 
-:paper: Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.: 
-SPOTting Model Parameters Using a Ready-Made Python Package, 
+:paper: Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.:
+SPOTting Model Parameters Using a Ready-Made Python Package,
 PLoS ONE, 10(12), e0145180, doi:10.1371/journal.pone.0145180, 2015.
 
-This package enables the comprehensive use of different Bayesian and Heuristic calibration 
-techniques in one Framework. It comes along with an algorithms folder for the 
+This package enables the comprehensive use of different Bayesian and Heuristic calibration
+techniques in one Framework. It comes along with an algorithms folder for the
 sampling and an analyser class for the plotting of results by the sampling.
 
-:dependencies: - Numpy >1.8 (http://www.numpy.org/) 
-               - Pandas >0.13 (optional) (http://pandas.pydata.org/)
-               - Matplotlib >1.4 (optional) (http://matplotlib.org/) 
+:dependencies: - Numpy >2 (https://www.numpy.org/)
+               - Pandas >1 (optional) (https://pandas.pydata.org/)
+               - Matplotlib >1.4 (optional) (https://matplotlib.org/)
                - CMF (optional) (http://fb09-pasig.umwelt.uni-giessen.de:8000/)
-               - mpi4py (optional) (http://mpi4py.scipy.org/)
-               - pathos (optional) (https://pypi.python.org/pypi/pathos/)
-               - sqlite3 (optional) (https://pypi.python.org/pypi/sqlite3/)
+               - mpi4py (optional) (https://mpi4py.readthedocs.io/en/stable/)
+               - pathos (optional) (https://pathos.readthedocs.io/en/latest/)
+               - sqlite3 (optional) (https://docs.python.org/3/library/sqlite3.html)
 
                :help: For specific questions, try to use the documentation website at:
                 http://fb09-pasig.umwelt.uni-giessen.de/spotpy/

--- a/src/spotpy/examples/hymod_python/hymod.py
+++ b/src/spotpy/examples/hymod_python/hymod.py
@@ -6,8 +6,8 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 :author: Tobias Houska and Benjamin Manns
 
-:paper: Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.: 
-SPOTting Model Parameters Using a Ready-Made Python Package, 
+:paper: Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.:
+SPOTting Model Parameters Using a Ready-Made Python Package,
 PLoS ONE, 10(12), e0145180, doi:10.1371/journal.pone.0145180, 2015.
 """
 

--- a/src/spotpy/examples/hymod_unix/__init__.py
+++ b/src/spotpy/examples/hymod_unix/__init__.py
@@ -5,21 +5,21 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 :author: Tobias Houska
 
-:paper: Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.: 
-SPOTting Model Parameters Using a Ready-Made Python Package, 
+:paper: Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.:
+SPOTting Model Parameters Using a Ready-Made Python Package,
 PLoS ONE, 10(12), e0145180, doi:10.1371/journal.pone.0145180, 2015.
 
-This package enables the comprehensive use of different Bayesian and Heuristic calibration 
-techniques in one Framework. It comes along with an algorithms folder for the 
+This package enables the comprehensive use of different Bayesian and Heuristic calibration
+techniques in one Framework. It comes along with an algorithms folder for the
 sampling and an analyser class for the plotting of results by the sampling.
 
-:dependencies: - Numpy >1.8 (http://www.numpy.org/) 
-               - Pandas >0.13 (optional) (http://pandas.pydata.org/)
-               - Matplotlib >1.4 (optional) (http://matplotlib.org/) 
+:dependencies: - Numpy >2 (https://www.numpy.org/)
+               - Pandas >1 (optional) (https://pandas.pydata.org/)
+               - Matplotlib >1.4 (optional) (https://matplotlib.org/)
                - CMF (optional) (http://fb09-pasig.umwelt.uni-giessen.de:8000/)
-               - mpi4py (optional) (http://mpi4py.scipy.org/)
-               - pathos (optional) (https://pypi.python.org/pypi/pathos/)
-               - sqlite3 (optional) (https://pypi.python.org/pypi/sqlite3/)
+               - mpi4py (optional) (https://mpi4py.readthedocs.io/en/stable/)
+               - pathos (optional) (https://pathos.readthedocs.io/en/latest/)
+               - sqlite3 (optional) (https://docs.python.org/3/library/sqlite3.html)
 
                :help: For specific questions, try to use the documentation website at:
                 http://fb09-pasig.umwelt.uni-giessen.de/spotpy/

--- a/src/spotpy/examples/spot_setup_ackley.py
+++ b/src/spotpy/examples/spot_setup_ackley.py
@@ -6,6 +6,7 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 This example implements the Ackley function into SPOT.
 """
+
 import numpy as np
 
 import spotpy

--- a/src/spotpy/examples/spot_setup_griewank.py
+++ b/src/spotpy/examples/spot_setup_griewank.py
@@ -6,6 +6,7 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 This example implements the Griewank function into SPOT.
 """
+
 import numpy as np
 
 import spotpy

--- a/src/spotpy/examples/spot_setup_hymod_exe.py
+++ b/src/spotpy/examples/spot_setup_hymod_exe.py
@@ -4,10 +4,9 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 :author: Tobias Houska
 This example implements the external hydrological model HYMOD into SPOTPY.
 """
+
 import os
 
-# from shutil import rmtree
-import sys
 from distutils.dir_util import copy_tree, remove_tree
 
 import numpy as np

--- a/src/spotpy/examples/spot_setup_hymod_exe.py
+++ b/src/spotpy/examples/spot_setup_hymod_exe.py
@@ -6,7 +6,6 @@ This example implements the external hydrological model HYMOD into SPOTPY.
 """
 
 import os
-
 from distutils.dir_util import copy_tree, remove_tree
 
 import numpy as np

--- a/src/spotpy/examples/spot_setup_hymod_python.py
+++ b/src/spotpy/examples/spot_setup_hymod_python.py
@@ -7,7 +7,6 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 This example implements the python version of hymod into SPOTPY.
 """
 
-
 import os
 
 from spotpy.examples.hymod_python.hymod import hymod

--- a/src/spotpy/examples/spot_setup_hymod_python_pareto.py
+++ b/src/spotpy/examples/spot_setup_hymod_python_pareto.py
@@ -7,7 +7,6 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 This example implements the python version of hymod into SPOTPY.
 """
 
-
 import os
 
 import numpy as np

--- a/src/spotpy/examples/spot_setup_hymod_unix.py
+++ b/src/spotpy/examples/spot_setup_hymod_unix.py
@@ -18,7 +18,6 @@ except ImportError:
     import spotpy
 
 import os
-
 import sys
 from distutils.dir_util import copy_tree, remove_tree
 

--- a/src/spotpy/examples/spot_setup_hymod_unix.py
+++ b/src/spotpy/examples/spot_setup_hymod_unix.py
@@ -6,6 +6,7 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 This example implements the external hydrological model HYMOD into SPOTPY.
 """
+
 import numpy as np
 
 try:
@@ -16,10 +17,8 @@ except ImportError:
     sys.path.append(".")
     import spotpy
 
-import multiprocessing as mp
 import os
 
-# from shutil import rmtree
 import sys
 from distutils.dir_util import copy_tree, remove_tree
 

--- a/src/spotpy/examples/spot_setup_standardnormal.py
+++ b/src/spotpy/examples/spot_setup_standardnormal.py
@@ -6,6 +6,7 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 This example implements the Standard Normal function into SPOT.
 """
+
 import numpy as np
 
 import spotpy

--- a/src/spotpy/likelihoods.py
+++ b/src/spotpy/likelihoods.py
@@ -504,8 +504,8 @@ def generalizedLikelihoodFunction(data, comparedata, measerror=None, params=None
         missingparams = []
         randomparset, parameternames = params
         parameternames = np.array(parameternames)
-        #randomparset = np.array(randomparset)
-        randomparset = [np.array(par) for par in randomparset] 
+        # randomparset = np.array(randomparset)
+        randomparset = [np.array(par) for par in randomparset]
         for nm in paramDependencies:
             if nm not in parameternames:
                 missingparams.append(nm)
@@ -568,9 +568,7 @@ def generalizedLikelihoodFunction(data, comparedata, measerror=None, params=None
         )
         M_2 = 1
         sigma_xi = np.sqrt(
-            np.abs(
-                float((M_2 - M_1**2) * (xi**2 + xi ** (-2)) + 2 * M_1**2 - M_2)
-            )
+            np.abs(float((M_2 - M_1**2) * (xi**2 + xi ** (-2)) + 2 * M_1**2 - M_2))
         )
         cBeta = (math.gamma(3 * (1 + beta) / 2) / math.gamma((1 + beta) / 2)) ** (
             1 / (1 + beta)
@@ -699,9 +697,7 @@ def SkewedStudentLikelihoodHomoscedastic(data, comparedata, measerror=None):
 
     # TODO Maximizing with negative to zero?
     # Original: -np.prod(1 / (np.sqrt(2 * np.pi) * measerror) * np.exp(-1 * (res ** 2) / (2)))
-    return -np.sum(
-        (1 / (np.sqrt(2 * np.pi) * measerror) * np.exp(-1 * (res**2) / (2)))
-    )
+    return -np.sum((1 / (np.sqrt(2 * np.pi) * measerror) * np.exp(-1 * (res**2) / (2))))
 
 
 def SkewedStudentLikelihoodHeteroscedastic(
@@ -957,9 +953,7 @@ def SkewedStudentLikelihoodHeteroscedasticAdvancedARModel(
             return np.NAN
 
     N = data.__len__()
-    eta_all = (res[1:] - phi * res[:-1] + phi / (N) * np.sum(res)) * np.sqrt(
-        1 - phi**2
-    )
+    eta_all = (res[1:] - phi * res[:-1] + phi / (N) * np.sum(res)) * np.sqrt(1 - phi**2)
 
     c_1 = (
         (k**2 - 1 / (k**2))

--- a/src/spotpy/parameter.py
+++ b/src/spotpy/parameter.py
@@ -47,10 +47,10 @@ class _ArgumentHelper(object):
         :return: name
         """
         # Check if args[0] is string like (and exists)
-        #if self.args and str(self.args[0]) == self.args[0]:
-        #if self.args and (str(self.args[0]) == self.args[0]):
+        # if self.args and str(self.args[0]) == self.args[0]:
+        # if self.args and (str(self.args[0]) == self.args[0]):
         if self.args and (isinstance(self.args[0], str)):
-        #if (self.args & isinstance(self.args[0], str)).all():
+            # if (self.args & isinstance(self.args[0], str)).all():
             name = self.args.pop(0)
             self.processed_args += 1
         # else get the name from the keywords

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -217,6 +217,7 @@ class TestAlgorithms(unittest.TestCase):
         sampler.sample(generations, n_obj=3, n_pop=n_pop)
         results = sampler.getdata()
         self.assertLessEqual(len(results), generations * n_pop)
+
     # def test_padds(self):
     #     sampler = spotpy.algorithms.padds(
     #         spot_setup_hymod(self.multi_obj_func),
@@ -228,8 +229,6 @@ class TestAlgorithms(unittest.TestCase):
     #     sampler.sample(int(self.rep * 0.5), metric="ones")
     #     results = sampler.getdata()
     #     self.assertEqual(len(results) + 5, int(self.rep * 0.5))
-
-
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_setup_parameters.py
+++ b/tests/test_setup_parameters.py
@@ -6,6 +6,7 @@ This file is part of Statistical Parameter Optimization Tool for Python(SPOTPY).
 Tests the various possibilities to create and use parameters
 Focus especially the usage of parameters as class attributes
 """
+
 import inspect
 import sys
 import unittest

--- a/tutorials/3dplot.py
+++ b/tutorials/3dplot.py
@@ -6,6 +6,7 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 This file shows how to make 3d surface plots.
 """
+
 import matplotlib.pyplot as plt
 from matplotlib import cm
 from matplotlib.ticker import FormatStrFormatter, LinearLocator
@@ -27,7 +28,7 @@ X, Y = meshgrid(X, Y)
 # from spot_setup_griewank import spot_setup
 from spotpy.examples.spot_setup_ackley import spot_setup
 
-Z = np.zeros(X.shape)
+Z = zeros(X.shape)
 for i in range(X.shape[0]):
     for j in range(X.shape[1]):
         sim = spot_setup().simulation([X[i, j], Y[i, j]])

--- a/tutorials/cli_hymod.py
+++ b/tutorials/cli_hymod.py
@@ -3,7 +3,6 @@ Shows the usage of the command line interface CLI
 
 """
 
-
 from spotpy.cli import main
 from spotpy.examples.spot_setup_hymod_python import spot_setup
 

--- a/tutorials/dds/__init__.py
+++ b/tutorials/dds/__init__.py
@@ -5,21 +5,21 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 :author: Tobias Houska
 
-:paper: Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.: 
-SPOTting Model Parameters Using a Ready-Made Python Package, 
+:paper: Houska, T., Kraft, P., Chamorro-Chavez, A. and Breuer, L.:
+SPOTting Model Parameters Using a Ready-Made Python Package,
 PLoS ONE, 10(12), e0145180, doi:10.1371/journal.pone.0145180, 2015.
 
-This package enables the comprehensive use of different Bayesian and Heuristic calibration 
-techniques in one Framework. It comes along with an algorithms folder for the 
+This package enables the comprehensive use of different Bayesian and Heuristic calibration
+techniques in one Framework. It comes along with an algorithms folder for the
 sampling and an analyser class for the plotting of results by the sampling.
 
-:dependencies: - Numpy >1.8 (http://www.numpy.org/) 
-               - Pandas >0.13 (optional) (http://pandas.pydata.org/)
-               - Matplotlib >1.4 (optional) (http://matplotlib.org/) 
+:dependencies: - Numpy >2 (https://www.numpy.org/)
+               - Pandas >1 (optional) (https://pandas.pydata.org/)
+               - Matplotlib >1.4 (optional) (https://matplotlib.org/)
                - CMF (optional) (http://fb09-pasig.umwelt.uni-giessen.de:8000/)
-               - mpi4py (optional) (http://mpi4py.scipy.org/)
-               - pathos (optional) (https://pypi.python.org/pypi/pathos/)
-               - sqlite3 (optional) (https://pypi.python.org/pypi/sqlite3/)
+               - mpi4py (optional) (https://mpi4py.readthedocs.io/en/stable/)
+               - pathos (optional) (https://pathos.readthedocs.io/en/latest/)
+               - sqlite3 (optional) (https://docs.python.org/3/library/sqlite3.html)
 
                :help: For specific questions, try to use the documentation website at:
                 http://fb09-pasig.umwelt.uni-giessen.de/spotpy/

--- a/tutorials/gui_hymod.py
+++ b/tutorials/gui_hymod.py
@@ -4,7 +4,6 @@ Shows the usage of the matplotlib GUI
 Needs at least Python 3.5
 """
 
-
 import spotpy
 from spotpy.examples.spot_setup_hymod_python import spot_setup
 from spotpy.gui.mpl import GUI

--- a/tutorials/tutorial_Parameterlist_iterator.py
+++ b/tutorials/tutorial_Parameterlist_iterator.py
@@ -6,6 +6,7 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 This example implements the Rosenbrock function into SPOT.
 """
+
 import numpy as np
 
 import spotpy
@@ -49,4 +50,4 @@ sampler = spotpy.algorithms.mc(
 )  # Parameter lists can be sampled with MC
 sampler.sample(
     10
-)  # Choose equaly or less repetitions as you have parameters in your List
+)  # Choose equaly or fewer repetitions as you have parameters in your List

--- a/tutorials/tutorial_cmf_lumped.py
+++ b/tutorials/tutorial_cmf_lumped.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-"""
-
-"""
-
 import datetime
 import os
 import sys

--- a/tutorials/tutorial_efast_hymod.py
+++ b/tutorials/tutorial_efast_hymod.py
@@ -39,19 +39,21 @@ if __name__ == "__main__":
     res = spotpy.analyser.get_modelruns(results)
 
     # calculate the sensitivities
-    sampler.calc_sensitivity(results, dbname = "eFAST_sens_hymod")
+    sampler.calc_sensitivity(results, dbname="eFAST_sens_hymod")
 
     # plot the temporal parameter sensitivities
-    spotpy.analyser.plot_efast(dbname="eFast_sens_hymod", fig_name="efast_sensitivities.png")
+    spotpy.analyser.plot_efast(
+        dbname="eFast_sens_hymod", fig_name="efast_sensitivities.png"
+    )
 
-    # In case of more than on model output: 
+    # In case of more than on model output:
     # seperate restults from each other (in case more than one model output is saved in the database)
     # res = spotpy.analyser.get_modelruns_list(results)
 
-    #for i in range(len(res)):
+    # for i in range(len(res)):
 
-        # calculate the sensitivities
+    # calculate the sensitivities
     #    sampler.calc_sensitivity(results, dbname = "eFAST_sens_hymod"+str(i))
 
-        # plot the temporal parameter sensitivities
+    # plot the temporal parameter sensitivities
     #    spotpy.analyser.plot_efast(dbname="eFast_sens_hymod", fig_name="sens"+str(i)+"png")

--- a/tutorials/tutorial_listsampler.py
+++ b/tutorials/tutorial_listsampler.py
@@ -4,7 +4,7 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 :author: Tobias Houska
 
-This example implements the Rosenbrock function into SPOT.  
+This example implements the Rosenbrock function into SPOT.
 """
 
 import spotpy
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     results = spotpy.analyser.load_csv_results("FAST_hymodlist")
 
     # 2.5 Please mind that these results contains the same data as we have used
-    # the same spot_setup. However we could have also used another spot_setup,
+    # the same spot_setup. However, we could have also used another spot_setup,
     # which takes the same parameters.
     #############################################################
 

--- a/tutorials/tutorial_own_database.py
+++ b/tutorials/tutorial_own_database.py
@@ -6,6 +6,7 @@ This file is part of Statistical Parameter Estimation Tool (SPOTPY).
 
 This example implements the Rosenbrock function into SPOT.
 """
+
 import numpy as np
 
 import spotpy
@@ -52,5 +53,5 @@ if __name__ == "__main__":
     sampler = spotpy.algorithms.mc(spot_setup, dbformat="custom")
     sampler.sample(
         100
-    )  # Choose equal or less repetitions as you have parameters in your List
+    )  # Choose equal or fewer repetitions as you have parameters in your List
     spot_setup.database.close()  # Close the created txt file


### PR DESCRIPTION
Hi there,

I couldn't help but notice a few typos when running `spotpy` and decided to do a very quick code cleanup. Changes in this PR are:

- Correcting spelling/grammar errors
- Configuring the package metadata to reflect the lowest-supported Python (3.9+)
- Added build tests for Python3.9 in GitHub Workflow
- Configuring `black` for Python3.9+
- Running `python -m black` over the code base
- Adding `black` to the code linting checks in GitHub Workflow
- Dropped support for Python3.9, extended support to Python3.13

Let me know if there are any changes you'd like me to make.

Best,